### PR TITLE
add Manjaro ARM to Vim3 thirdparty firmware

### DIFF
--- a/source/vim3/FirmwareThirdparty.md
+++ b/source/vim3/FirmwareThirdparty.md
@@ -17,3 +17,8 @@ title: Khadas VIM3 Third Party Firmware
 
 ## ArchLinux
 **ArchLinux image built by balbes150, thanks balbes150.**
+
+## Manjaro ARM
+### USB/SD Card installation
+* [KDE](https://osdn.net/projects/manjaro-arm/storage/vim3/kde/)
+* [MATE](https://osdn.net/projects/manjaro-arm/storage/vim3/mate/)


### PR DESCRIPTION
This adds links to the Manjaro ARM images for the Vim 3.