### PR TITLE
Update pip3 install instructions

### DIFF
--- a/source/vim3/HowToUseNpu.md
+++ b/source/vim3/HowToUseNpu.md
@@ -29,7 +29,7 @@ Host PC OS requirement:
 $ sudo apt update
 $ sudo apt install python3 python3-pip python3-virtualenv
 $ cd ~/npu/aml_npu_sdk/acuity-toolkit
-$ for req in $(cat requirements.txt); do pip3 install $req; done
+$ pip3 install -r requirements.txt
 ```
 
 *Note: The command will install TensorFlow CPU version by default, if your PC has NVIDIA GPU(s) you can choose to install [GPU version](https://www.tensorflow.org/install/gpu) to speed up the conversion.*


### PR DESCRIPTION
No need for the bash loop.

Standard way of using the requirements.txt is to use `pip{3} install -r <file>`