### PR TITLE
Added sudo in front of toneboard-burning-tool

### DIFF
--- a/source/toneboard/HowtoUpgradeFirmware.md
+++ b/source/toneboard/HowtoUpgradeFirmware.md
@@ -120,7 +120,7 @@ Bus 001 Device 005: ID 20b1:0008 XMOS Ltd
 * Finally, run the tool with your firmware file of choice (drag and drop your `.bin` file to replace `/path/to/firmware.bin`).
 
 ```
-$ toneboard-burn-tool -i /path/to/firmware.bin
+$ sudo toneboard-burn-tool -i /path/to/firmware.bin
 ```
 *Note: Upgrading will stuck at `Waiting for device to restart and enter DFU mode` for about 20 seconds, please wait patiently.*
 


### PR DESCRIPTION
Forum user complained about the lack of sudo in the instructions for Ubuntu and Mac:

https://forum.khadas.com/t/tone-board-v1-04-firmware-update/4008/9?u=tsangyoujun